### PR TITLE
Setup monorepo linting

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint monorepo
+        run: npm run lint:monorepo
+
       - name: Lint app
         run: npm run lint -w=apps/app
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint monorepo
+        run: npm run lint:monorepo
+
       - name: Lint website
         run: npm run lint -w=apps/website
 

--- a/.github/workflows/preview-app.yml
+++ b/.github/workflows/preview-app.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint monorepo
+        run: npm run lint:monorepo
+
       - name: Lint app
         run: npm run lint -w=apps/app
 

--- a/.github/workflows/preview-website.yml
+++ b/.github/workflows/preview-website.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint monorepo
+        run: npm run lint:monorepo
+
       - name: Lint website
         run: npm run lint -w=apps/website
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "devDependencies": {
         "prettier": "^3.6.2",
+        "sherif": "^1.6.1",
         "turbo": "^2.5.6"
       }
     },
@@ -10077,6 +10078,108 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sherif": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sherif/-/sherif-1.6.1.tgz",
+      "integrity": "sha512-ZnwyTnmXoUOPClkOA37JWIyFxCoozMGHmhk/p7XbTREI554XXCnBAn3BMX8UsqkhSzQ9eNQsq4U+jnImEIppsQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "sherif": "index.js"
+      },
+      "optionalDependencies": {
+        "sherif-darwin-arm64": "1.6.1",
+        "sherif-darwin-x64": "1.6.1",
+        "sherif-linux-arm64": "1.6.1",
+        "sherif-linux-x64": "1.6.1",
+        "sherif-windows-arm64": "1.6.1",
+        "sherif-windows-x64": "1.6.1"
+      }
+    },
+    "node_modules/sherif-darwin-arm64": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sherif-darwin-arm64/-/sherif-darwin-arm64-1.6.1.tgz",
+      "integrity": "sha512-J15oBJcrnCAZ0rQE8WbMShYw3204A18akCH6C/uZrILTwX/vZyJIqi7lAt5L00LzsadA3HcyQqVjLNNCvuihoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sherif-darwin-x64": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sherif-darwin-x64/-/sherif-darwin-x64-1.6.1.tgz",
+      "integrity": "sha512-oLA/GtvUasi+qCl35LczOhQ4g/xY2mxE5/eiTYQGT3Ow7FKLscnkE6v5l28bgkFeR/uke0AgZ/CgHhozAf0ulg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/sherif-linux-arm64": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sherif-linux-arm64/-/sherif-linux-arm64-1.6.1.tgz",
+      "integrity": "sha512-OoltlucT7v9BZdkYZRbs1QU0DYMCQ5qgpMqQdMW1Rq3w3amr7+oEiV9NHntD83udOo8xRxKq0uPXfNYu+VptJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sherif-linux-x64": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sherif-linux-x64/-/sherif-linux-x64-1.6.1.tgz",
+      "integrity": "sha512-qyDyYqpi3ABGkRuCnjnxN3OMT8DxMiiLzhS9p9xC05Y9nr5hjkxvqP4DdJ4e5opm4E7vzRAS7VQoZ6m7h6tsgQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/sherif-windows-arm64": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sherif-windows-arm64/-/sherif-windows-arm64-1.6.1.tgz",
+      "integrity": "sha512-wAbCiqP//lo7bZUlHmZUV3/sGjnJxo6QB5/fqhz5/GUeWh4CTyvlSacJKZxLnXnzpiUSeFnWutquWnHkRov5Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/sherif-windows-x64": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sherif-windows-x64/-/sherif-windows-x64-1.6.1.tgz",
+      "integrity": "sha512-2r0qMxZGCMO2aq8Hlq7npxtAsUFVDsEFtUM/6dFo1npa/jHe2mbU7ii/Ymy0bloSa/qw/azrSfRV6GLU7Gjtxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/shiki": {
       "version": "3.12.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "format": "prettier --write .",
     "lint": "turbo lint",
     "lint:fix": "turbo lint -- --fix",
+    "lint:monorepo": "sherif",
+    "lint:monorepo:fix": "sherif --fix",
     "preview": "turbo preview",
     "test": "turbo test"
   },
@@ -19,6 +21,7 @@
   ],
   "devDependencies": {
     "prettier": "^3.6.2",
+    "sherif": "^1.6.1",
     "turbo": "^2.5.6"
   }
 }


### PR DESCRIPTION
This update sets up scripting and CI tools for linting the monorepo to keep everything in top-notch shape.

We are using Sherif for this. Sherif will make sure:

- Package.json does not have empty dependency fields
- A given dependency uses the same version across the monorepo
- Similar dependencies (i.e. react and react-doc) should use the same version
- There are no non-existent packages in the monorepo
- There are no packages without package.json in the monorepo
- The root package manager filed is set
- The root package.json is set to private to avoid accidental publishing
- Private packages shouldn't have @types/* in dependencies
- Dependencies should be ordered alphabetically

Why do we specify dependencies in each package instead of repo-wide? Because it's a best practice. Tools like sherif can be used to prevent having multiple versions of the same dependency in the project. 

See [keeping dependencies on the same version](https://turborepo.com/docs/crafting-your-repository/managing-dependencies#keeping-dependencies-on-the-same-version) in the Turborepo documentation.